### PR TITLE
Note about friends & family option

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
                   <div class="alert alert-info">Please make sure you've put the cash in the metal box next to the laser.</div>
                 </div>
                 <div role="tabpanel" class="tab-pane" id="paypal">
-                  <div class="alert alert-info">Send the total to laser@nycresistor.com.</div>
+                  <div class="alert alert-info">Send the total to laser@nycresistor.com. Make sure to select the "Friends and Family" option when prompted.</div>
                   <div class="alert alert-danger"><strong>Don't login to PayPal from the laser computer.</strong></div>
                 </div>
                 <div role="tabpanel" class="tab-pane" id="tab">


### PR DESCRIPTION
PayPal has two ways you can categorize payments: for a "service", and for "friends and family". The difference is that for a "service", the payee gets hit with a PayPal fee, but the "friends and family" option does not incur a fee at all (unless you use a card, then the person paying pays a fee).

We were talking about this during craft night and I thought it would be a good idea to make this more obvious on the tracker.